### PR TITLE
Added Method to create client and wait for connectivity

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -15,6 +15,16 @@ func NewClient(url string) *Client {
 	return &Client{url}
 }
 
+func NewClientAndWait(url string) (*Client, error) {
+	client := &Client{url}
+
+	if err := testConnection(client); err != nil {
+		return nil, err
+	}
+
+	return client, nil
+}
+
 func (m *Client) SendRequest(path string) ([]byte, error) {
 	client := &http.Client{}
 	req, err := http.NewRequest("GET", m.url+path, nil)

--- a/metadata/utils.go
+++ b/metadata/utils.go
@@ -1,0 +1,19 @@
+package metadata
+
+import (
+	"time"
+)
+
+func testConnection(mdClient *Client) error {
+	var err error
+	maxTime := 20 * time.Second
+
+	for i := 1 * time.Second; i < maxTime; i *= time.Duration(2) {
+		if _, err = mdClient.GetVersion(); err != nil {
+			time.Sleep(i)
+		} else {
+			return nil
+		}
+	}
+	return err
+}


### PR DESCRIPTION
Metadata service is not always immediately available, this adds a method
that tests with a backoff. It will time out after ~49 seconds.
