### PR TITLE
alena1108	Pin to specific version rather than pointing to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	metadataUrl = "http://rancher-metadata/latest"
+	metadataUrl = "http://rancher-metadata/2015-07-25"
 )
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	metadataUrl = "http://rancher-metadata/latest"
+	metadataUrl = "http://rancher-metadata/2015-07-25"
 )
 
 func main() {

--- a/metadata/types.go
+++ b/metadata/types.go
@@ -13,7 +13,6 @@ type Service struct {
 	Kind        string                 `json:"kind"`
 	Hostname    string                 `json:"hostname"`
 	Vip         string                 `json:"vip"`
-	CreateIndex int                    `json:"create_index"`
 	UUID        string                 `json:"uuid"`
 	ExternalIps []string               `json:"external_ips"`
 	Sidekicks   []string               `json:"sidekicks"`


### PR DESCRIPTION
1) Pin to specific version rather than pointing to latest
2) Removed createIndex

Once proper versioning system is in place for go-rancher-metadata, we are going to:
- put createIndex to 2015-12-19/latest as support for it was added only in this version
- return service.containers/stack.containers as object for 2015-12-19/latest  metadata

Today go-rancher-metadata supports only 2015-07-25 version
