### PR TITLE
Fixing a bug in Host struct where host_id is used instead of hostId

### DIFF
--- a/metadata/types.go
+++ b/metadata/types.go
@@ -56,7 +56,7 @@ type Container struct {
 type Host struct {
 	Name     string            `json:"name"`
 	AgentIP  string            `json:"agent_ip"`
-	HostId   int               `json:"host_id"`
+	HostId   int               `json:"hostId"`
 	Labels   map[string]string `json:"labels"`
 	UUID     string            `json:"uuid"`
 	Hostname string            `json:"hostname"`


### PR DESCRIPTION
Output from the command line.

```
curl http://rancher-metadata/2015-12-19/self/host
agent_ip
hostId
hostname
labels/
name
uuid
```
