### PR TITLE
Adding option to specify Client IP address

### DIFF
--- a/tests/answers.host1.yml
+++ b/tests/answers.host1.yml
@@ -1,0 +1,914 @@
+'2015-07-25':
+  default:
+    containers:
+    - &id011
+      create_index: 1
+      external_id: 779f71ede6f82f3adce7efa0b3ba6c6dc44c103e14e3065425b67cc8bbe96432
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.128.187
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 20e2f2b1-f6fd-4d06-b387-3c1e3a702d5a
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/mongo
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/mongo
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+        io.rancher.container.uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+        io.rancher.container.name: rocket-chat_mongo_1
+        io.rancher.container.ip: 10.42.128.187/16
+      name: rocket-chat_mongo_1
+      ports: []
+      primary_ip: 10.42.128.187
+      service_index: '1'
+      service_name: mongo
+      stack_uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+    - &id012
+      create_index: null
+      external_id: f5ad0d2bb345471c5ae6dd14995d791b82246889e63b516fa0b5e0084353f331
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.221.125
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '4'
+        io.rancher.container.ip: 10.42.221.125/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.221.125
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+    - &id013
+      create_index: 1
+      external_id: d75ca8b68526de0bab930bf50e1ec1366b91a8805cb11f3bd33760f90f23a361
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.207.141
+      labels:
+        io.rancher.project.name: ghost
+        io.rancher.service.deployment.unit: 734ab88d-a730-444a-8e84-be3fd5dfd123
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: ghost/ghost
+        io.rancher.stack.name: ghost
+        io.rancher.stack_service.name: ghost/ghost
+        io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+        io.rancher.container.uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+        io.rancher.container.name: ghost_ghost_1
+        io.rancher.container.ip: 10.42.207.141/16
+      name: ghost_ghost_1
+      ports:
+      - 130.211.160.79:8987:2368/tcp
+      primary_ip: 10.42.207.141
+      service_index: '1'
+      service_name: ghost
+      stack_name: ghost
+      start_count: 1
+      state: running
+      uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+    - &id014
+      create_index: 1
+      external_id: 648aa7d8a6c4eb32c9617186a37c7278b71c5e4c4af9523eb7fd38387608fb6c
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.228.29
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: 31f6b033-f70f-4b05-9023-48c455b21443
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/alpha
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/alpha
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+        io.rancher.container.uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+        io.rancher.container.name: triple_alpha_1
+        io.rancher.container.ip: 10.42.228.29/16
+      name: triple_alpha_1
+      ports:
+      - 130.211.160.79:40001:80/tcp
+      primary_ip: 10.42.228.29
+      service_index: '1'
+      service_name: alpha
+      stack_uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+    - &id004
+      create_index: 1
+      external_id: 5573e7627fe7c85defc6a20d07d3da2c9da65f3b29611e0d1cf3d9ceb57d6747
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.73.81
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 62c74524-7e7f-4509-8c23-922fbedc8d59
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/rocketchat
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/rocketchat
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+        io.rancher.container.uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+        io.rancher.container.name: rocket-chat_rocketchat_1
+        io.rancher.container.ip: 10.42.73.81/16
+      name: rocket-chat_rocketchat_1
+      ports:
+      - 104.155.135.97:3000:3000/tcp
+      primary_ip: 10.42.73.81
+      service_index: '1'
+      service_name: rocketchat
+      stack_uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+    - &id015
+      create_index: null
+      external_id: 46ba9baec31c016ffaaff659da8f296bcf3854fa580da87f6d564c4994dffa1c
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.53.162
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '5'
+        io.rancher.container.ip: 10.42.53.162/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.53.162
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+    - &id001
+      create_index: 1
+      external_id: 1e7de486fd7a1213edd377218de6fc62010e4f733356d879521983ce90a6f127
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.114.70
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 39dc601a-1a03-46bb-b925-643ffcc2dc71
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/db
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/db
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+        io.rancher.container.uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+        io.rancher.container.name: wordpress_db_1
+        io.rancher.container.ip: 10.42.114.70/16
+      name: wordpress_db_1
+      ports: []
+      primary_ip: 10.42.114.70
+      service_index: '1'
+      service_name: db
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+    - &id008
+      create_index: 1
+      external_id: f987f4dd7004d95e4647f9f2f4c65732cfd817b9179b3b74676e6a4f0a55d060
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.248.225
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: b5192eb8-4345-466f-b486-60154aef9115
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/charlie
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/charlie
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+        io.rancher.container.uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+        io.rancher.container.name: triple_charlie_1
+        io.rancher.container.ip: 10.42.248.225/16
+      name: triple_charlie_1
+      ports:
+      - 104.155.135.97:40003:80/tcp
+      primary_ip: 10.42.248.225
+      service_index: '1'
+      service_name: charlie
+      stack_uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+    - &id016
+      create_index: 1
+      external_id: 172e18f098643c47de02f8b050790f797bac66413184d4359cb2b02618f0530e
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.223.250
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 319aaf3d-33b7-4cd6-b177-4169e8f3a5fb
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/hubot
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/hubot
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+        io.rancher.container.uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+        io.rancher.container.name: rocket-chat_hubot_1
+        io.rancher.container.ip: 10.42.223.250/16
+      name: rocket-chat_hubot_1
+      ports:
+      - 104.155.146.133:3001:8080/tcp
+      primary_ip: 10.42.223.250
+      service_index: '1'
+      service_name: hubot
+      stack_uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+    - &id017
+      create_index: null
+      external_id: 1664a225ff2f47294234285f13786a359c2379698f586f67f4554ff79e2b6c24
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.105.87
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '6'
+        io.rancher.container.ip: 10.42.105.87/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.105.87
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+    - &id018
+      create_index: 1
+      external_id: 9a28718f55a59e398a95935ec1ec567b86ddeef207835a682662583b0c4c3b36
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.187.22
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 8e6c4f99-77a1-410d-aa48-cd9c14f0474e
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/wordpress
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/wordpress
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+        io.rancher.container.uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+        io.rancher.container.name: wordpress_wordpress_1
+        io.rancher.container.ip: 10.42.187.22/16
+      name: wordpress_wordpress_1
+      ports:
+      - 104.155.146.133:8484:80/tcp
+      primary_ip: 10.42.187.22
+      service_index: '1'
+      service_name: wordpress
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+    - &id019
+      create_index: 1
+      external_id: 2c50f56e006ea76c8c8966b270ae417c29c67532ea82b07ee0fd966cb52f1f4f
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.68.158
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: 6e902556-c228-4ec7-8724-99ecfe7c6bbb
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/bravo
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/bravo
+        io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+        io.rancher.container.uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+        io.rancher.container.name: triple_bravo_1
+        io.rancher.container.ip: 10.42.68.158/16
+      name: triple_bravo_1
+      ports:
+      - 104.155.146.133:40002:80/tcp
+      primary_ip: 10.42.68.158
+      service_index: '1'
+      service_name: bravo
+      stack_uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 104.155.135.97
+        hostId: 2
+        hostname: aa-leo-tmp-10acre-1
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-1
+        uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    services:
+    - containers:
+      - rocket-chat_mongo_1
+      expose: &id020 []
+      external_ips: &id021 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id022
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+      links: {}
+      metadata: &id023
+        io.rancher.service.hash: 16294d680b8d3cbf5967a29a833bdec0730e25d5
+      name: mongo
+      ports: &id024 []
+      scale: 1
+      sidekicks: &id025 []
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - &id006
+      containers:
+      - rocket-chat_rocketchat_1
+      expose: &id026 []
+      external_ips: &id027 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id028
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+      links:
+        rocket-chat/mongo: mongo
+      metadata: &id029
+        io.rancher.service.hash: e7379577e1059c3c7ef84ae610d5ad26da9fe25b
+      name: rocketchat
+      ports: &id030
+      - 3000:3000/tcp
+      scale: 1
+      sidekicks: &id031 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - containers:
+      - rocket-chat_hubot_1
+      expose: &id032 []
+      external_ips: &id033 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id034
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: &id035
+        io.rancher.service.hash: b1ef36ea20e8dbdefb29b5f0a5a27cc1628fb433
+      name: hubot
+      ports: &id036
+      - 3001:8080/tcp
+      scale: 1
+      sidekicks: &id037 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - containers:
+      - ghost_ghost_1
+      expose: &id038 []
+      external_ips: &id039 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id040
+        io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+      links: {}
+      metadata: &id041
+        io.rancher.service.hash: f49280e1f709117b76693b638834791e4f4ef0fd
+      name: ghost
+      ports: &id042
+      - 8987:2368/tcp
+      scale: 1
+      sidekicks: &id043 []
+      stack_name: ghost
+      token: null
+      uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+      vip: null
+    - &id002
+      containers:
+      - wordpress_db_1
+      expose: &id044 []
+      external_ips: &id045 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id046
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+      links: {}
+      metadata: &id047
+        io.rancher.service.hash: 98d0039e2af5f4d47e0c2eef103b27e8f2717cd3
+      name: db
+      ports: &id048 []
+      scale: 1
+      sidekicks: &id049 []
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - containers:
+      - wordpress_wordpress_1
+      expose: &id050 []
+      external_ips: &id051 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id052
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+      links:
+        wordpress/db: mysql
+      metadata: &id053
+        io.rancher.service.hash: ed9d26dd9fce0e66bedfe5bc5e1dd0b92a856bf3
+      name: wordpress
+      ports: &id054
+      - 8484:80/tcp
+      scale: 1
+      sidekicks: &id055 []
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - containers:
+      - triple_alpha_1
+      expose: &id056 []
+      external_ips: &id057 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id058
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+      links: {}
+      metadata: &id059
+        io.rancher.service.hash: 8a10554df3bc6a092dd0099d9780457380526030
+      name: alpha
+      ports: &id060
+      - 40001:80/tcp
+      scale: 1
+      sidekicks: &id061 []
+      stack_name: triple
+      token: null
+      uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+      vip: null
+    - &id009
+      containers:
+      - triple_charlie_1
+      expose: &id062 []
+      external_ips: &id063 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id064
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+      links: {}
+      metadata: &id065
+        io.rancher.service.hash: b062d386eafe5066caa89eae642a7ed77f09bdde
+      name: charlie
+      ports: &id066
+      - 40003:80/tcp
+      scale: 1
+      sidekicks: &id067 []
+      stack_name: triple
+      token: null
+      uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+      vip: null
+    - containers:
+      - triple_bravo_1
+      expose: &id068 []
+      external_ips: &id069 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id070
+        io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+      links: {}
+      metadata: &id071
+        io.rancher.service.hash: 614c40a8effc3bd450e5ebe2345e4611acf9665c
+      name: bravo
+      ports: &id072
+      - 40002:80/tcp
+      scale: 1
+      sidekicks: &id073 []
+      stack_name: triple
+      token: null
+      uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+      vip: null
+    stacks:
+    - &id010
+      environment_name: Default
+      environment_uuid: adminProject
+      name: triple
+      services:
+      - alpha
+      - charlie
+      - bravo
+      uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+    - &id007
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - mongo
+      - rocketchat
+      - hubot
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: ghost
+      services:
+      - ghost
+      uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+    - &id003
+      environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - db
+      - wordpress
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 19-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.114.70:
+    self:
+      container: *id001
+      host: &id005
+        agent_ip: 104.155.135.97
+        hostId: 2
+        hostname: aa-leo-tmp-10acre-1
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-1
+        uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      service: *id002
+      stack: *id003
+  10.42.73.81:
+    self:
+      container: *id004
+      host: *id005
+      service: *id006
+      stack: *id007
+  10.42.248.225:
+    self:
+      container: *id008
+      host: *id005
+      service: *id009
+      stack: *id010
+latest: &id086
+  default:
+    containers:
+    - *id011
+    - *id012
+    - *id013
+    - *id014
+    - *id004
+    - *id015
+    - *id001
+    - *id008
+    - *id016
+    - *id017
+    - *id018
+    - *id019
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 104.155.135.97
+        hostId: 2
+        hostname: aa-leo-tmp-10acre-1
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-1
+        uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    services:
+    - &id077
+      containers:
+      - *id011
+      create_index: 1
+      expose: *id020
+      external_ips: *id021
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id022
+      links: {}
+      metadata: *id023
+      name: mongo
+      ports: *id024
+      scale: 1
+      sidekicks: *id025
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - &id078
+      containers:
+      - *id004
+      create_index: 1
+      expose: *id026
+      external_ips: *id027
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id028
+      links:
+        rocket-chat/mongo: mongo
+      metadata: *id029
+      name: rocketchat
+      ports: *id030
+      scale: 1
+      sidekicks: *id031
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - &id079
+      containers:
+      - *id016
+      create_index: 1
+      expose: *id032
+      external_ips: *id033
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id034
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: *id035
+      name: hubot
+      ports: *id036
+      scale: 1
+      sidekicks: *id037
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - &id080
+      containers:
+      - *id013
+      create_index: 1
+      expose: *id038
+      external_ips: *id039
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id040
+      links: {}
+      metadata: *id041
+      name: ghost
+      ports: *id042
+      scale: 1
+      sidekicks: *id043
+      stack_name: ghost
+      token: null
+      uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+      vip: null
+    - &id081
+      containers:
+      - *id001
+      create_index: 1
+      expose: *id044
+      external_ips: *id045
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id046
+      links: {}
+      metadata: *id047
+      name: db
+      ports: *id048
+      scale: 1
+      sidekicks: *id049
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - &id082
+      containers:
+      - *id018
+      create_index: 1
+      expose: *id050
+      external_ips: *id051
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id052
+      links:
+        wordpress/db: mysql
+      metadata: *id053
+      name: wordpress
+      ports: *id054
+      scale: 1
+      sidekicks: *id055
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - &id074
+      containers:
+      - *id014
+      create_index: 1
+      expose: *id056
+      external_ips: *id057
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id058
+      links: {}
+      metadata: *id059
+      name: alpha
+      ports: *id060
+      scale: 1
+      sidekicks: *id061
+      stack_name: triple
+      token: null
+      uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+      vip: null
+    - &id075
+      containers:
+      - *id008
+      create_index: 1
+      expose: *id062
+      external_ips: *id063
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id064
+      links: {}
+      metadata: *id065
+      name: charlie
+      ports: *id066
+      scale: 1
+      sidekicks: *id067
+      stack_name: triple
+      token: null
+      uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+      vip: null
+    - &id076
+      containers:
+      - *id019
+      create_index: 1
+      expose: *id068
+      external_ips: *id069
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id070
+      links: {}
+      metadata: *id071
+      name: bravo
+      ports: *id072
+      scale: 1
+      sidekicks: *id073
+      stack_name: triple
+      token: null
+      uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+      vip: null
+    stacks:
+    - &id085
+      environment_name: Default
+      environment_uuid: adminProject
+      name: triple
+      services:
+      - *id074
+      - *id075
+      - *id076
+      uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+    - &id084
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - *id077
+      - *id078
+      - *id079
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: ghost
+      services:
+      - *id080
+      uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+    - &id083
+      environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - *id081
+      - *id082
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 19-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.114.70:
+    self:
+      container: *id001
+      host: *id005
+      service: *id081
+      stack: *id083
+  10.42.73.81:
+    self:
+      container: *id004
+      host: *id005
+      service: *id078
+      stack: *id084
+  10.42.248.225:
+    self:
+      container: *id008
+      host: *id005
+      service: *id075
+      stack: *id085
+'2015-12-19': *id086
+

--- a/tests/answers.host2.yml
+++ b/tests/answers.host2.yml
@@ -1,0 +1,908 @@
+'2015-07-25':
+  10.42.207.141:
+    self:
+      container: &id001
+        create_index: 1
+        external_id: d75ca8b68526de0bab930bf50e1ec1366b91a8805cb11f3bd33760f90f23a361
+        health_state: null
+        host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+        hostname: null
+        ips:
+        - 10.42.207.141
+        labels:
+          io.rancher.project.name: ghost
+          io.rancher.service.deployment.unit: 734ab88d-a730-444a-8e84-be3fd5dfd123
+          io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+          io.rancher.project_service.name: ghost/ghost
+          io.rancher.stack.name: ghost
+          io.rancher.stack_service.name: ghost/ghost
+          io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+          io.rancher.container.uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+          io.rancher.container.name: ghost_ghost_1
+          io.rancher.container.ip: 10.42.207.141/16
+        name: ghost_ghost_1
+        ports:
+        - 130.211.160.79:8987:2368/tcp
+        primary_ip: 10.42.207.141
+        service_index: '1'
+        service_name: ghost
+        stack_name: ghost
+        start_count: 1
+        state: running
+        uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+      host: &id005
+        agent_ip: 130.211.160.79
+        hostId: 1
+        hostname: aa-leo-tmp-10acre-2
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-2
+        uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      service: &id002
+        containers:
+        - ghost_ghost_1
+        expose: &id011 []
+        external_ips: &id012 []
+        fqdn: null
+        hostname: null
+        kind: service
+        labels: &id013
+          io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+        links: {}
+        metadata: &id014
+          io.rancher.service.hash: f49280e1f709117b76693b638834791e4f4ef0fd
+        name: ghost
+        ports: &id015
+        - 8987:2368/tcp
+        scale: 1
+        sidekicks: &id016 []
+        stack_name: ghost
+        token: null
+        uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+        vip: null
+      stack: &id003
+        environment_name: Default
+        environment_uuid: adminProject
+        name: ghost
+        services:
+        - ghost
+        uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+  default:
+    containers:
+    - &id008
+      create_index: 1
+      external_id: 779f71ede6f82f3adce7efa0b3ba6c6dc44c103e14e3065425b67cc8bbe96432
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.128.187
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 20e2f2b1-f6fd-4d06-b387-3c1e3a702d5a
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/mongo
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/mongo
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+        io.rancher.container.uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+        io.rancher.container.name: rocket-chat_mongo_1
+        io.rancher.container.ip: 10.42.128.187/16
+      name: rocket-chat_mongo_1
+      ports: []
+      primary_ip: 10.42.128.187
+      service_index: '1'
+      service_name: mongo
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+    - &id018
+      create_index: null
+      external_id: f5ad0d2bb345471c5ae6dd14995d791b82246889e63b516fa0b5e0084353f331
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.221.125
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '4'
+        io.rancher.container.ip: 10.42.221.125/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.221.125
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+    - *id001
+    - &id004
+      create_index: 1
+      external_id: 648aa7d8a6c4eb32c9617186a37c7278b71c5e4c4af9523eb7fd38387608fb6c
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.228.29
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: 31f6b033-f70f-4b05-9023-48c455b21443
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/alpha
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/alpha
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+        io.rancher.container.uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+        io.rancher.container.name: triple_alpha_1
+        io.rancher.container.ip: 10.42.228.29/16
+      name: triple_alpha_1
+      ports:
+      - 130.211.160.79:40001:80/tcp
+      primary_ip: 10.42.228.29
+      service_index: '1'
+      service_name: alpha
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+    - &id019
+      create_index: 1
+      external_id: 5573e7627fe7c85defc6a20d07d3da2c9da65f3b29611e0d1cf3d9ceb57d6747
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.73.81
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 62c74524-7e7f-4509-8c23-922fbedc8d59
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/rocketchat
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/rocketchat
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+        io.rancher.container.uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+        io.rancher.container.name: rocket-chat_rocketchat_1
+        io.rancher.container.ip: 10.42.73.81/16
+      name: rocket-chat_rocketchat_1
+      ports:
+      - 104.155.135.97:3000:3000/tcp
+      primary_ip: 10.42.73.81
+      service_index: '1'
+      service_name: rocketchat
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+    - &id020
+      create_index: null
+      external_id: 46ba9baec31c016ffaaff659da8f296bcf3854fa580da87f6d564c4994dffa1c
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.53.162
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '5'
+        io.rancher.container.ip: 10.42.53.162/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.53.162
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+    - &id021
+      create_index: 1
+      external_id: 1e7de486fd7a1213edd377218de6fc62010e4f733356d879521983ce90a6f127
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.114.70
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 39dc601a-1a03-46bb-b925-643ffcc2dc71
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/db
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/db
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+        io.rancher.container.uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+        io.rancher.container.name: wordpress_db_1
+        io.rancher.container.ip: 10.42.114.70/16
+      name: wordpress_db_1
+      ports: []
+      primary_ip: 10.42.114.70
+      service_index: '1'
+      service_name: db
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+    - &id022
+      create_index: 1
+      external_id: f987f4dd7004d95e4647f9f2f4c65732cfd817b9179b3b74676e6a4f0a55d060
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.248.225
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: b5192eb8-4345-466f-b486-60154aef9115
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/charlie
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/charlie
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+        io.rancher.container.uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+        io.rancher.container.name: triple_charlie_1
+        io.rancher.container.ip: 10.42.248.225/16
+      name: triple_charlie_1
+      ports:
+      - 104.155.135.97:40003:80/tcp
+      primary_ip: 10.42.248.225
+      service_index: '1'
+      service_name: charlie
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+    - &id023
+      create_index: 1
+      external_id: 172e18f098643c47de02f8b050790f797bac66413184d4359cb2b02618f0530e
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.223.250
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 319aaf3d-33b7-4cd6-b177-4169e8f3a5fb
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/hubot
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/hubot
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+        io.rancher.container.uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+        io.rancher.container.name: rocket-chat_hubot_1
+        io.rancher.container.ip: 10.42.223.250/16
+      name: rocket-chat_hubot_1
+      ports:
+      - 104.155.146.133:3001:8080/tcp
+      primary_ip: 10.42.223.250
+      service_index: '1'
+      service_name: hubot
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+    - &id024
+      create_index: null
+      external_id: 1664a225ff2f47294234285f13786a359c2379698f586f67f4554ff79e2b6c24
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.105.87
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '6'
+        io.rancher.container.ip: 10.42.105.87/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.105.87
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+    - &id025
+      create_index: 1
+      external_id: 9a28718f55a59e398a95935ec1ec567b86ddeef207835a682662583b0c4c3b36
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.187.22
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 8e6c4f99-77a1-410d-aa48-cd9c14f0474e
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/wordpress
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/wordpress
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+        io.rancher.container.uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+        io.rancher.container.name: wordpress_wordpress_1
+        io.rancher.container.ip: 10.42.187.22/16
+      name: wordpress_wordpress_1
+      ports:
+      - 104.155.146.133:8484:80/tcp
+      primary_ip: 10.42.187.22
+      service_index: '1'
+      service_name: wordpress
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+    - &id026
+      create_index: 1
+      external_id: 2c50f56e006ea76c8c8966b270ae417c29c67532ea82b07ee0fd966cb52f1f4f
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.68.158
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: 6e902556-c228-4ec7-8724-99ecfe7c6bbb
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/bravo
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/bravo
+        io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+        io.rancher.container.uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+        io.rancher.container.name: triple_bravo_1
+        io.rancher.container.ip: 10.42.68.158/16
+      name: triple_bravo_1
+      ports:
+      - 104.155.146.133:40002:80/tcp
+      primary_ip: 10.42.68.158
+      service_index: '1'
+      service_name: bravo
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 130.211.160.79
+        hostId: 1
+        hostname: aa-leo-tmp-10acre-2
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-2
+        uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    services:
+    - &id009
+      containers:
+      - rocket-chat_mongo_1
+      expose: &id027 []
+      external_ips: &id028 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id029
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+      links: {}
+      metadata: &id030
+        io.rancher.service.hash: 16294d680b8d3cbf5967a29a833bdec0730e25d5
+      name: mongo
+      ports: &id031 []
+      scale: 1
+      sidekicks: &id032 []
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - containers:
+      - rocket-chat_rocketchat_1
+      expose: &id033 []
+      external_ips: &id034 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id035
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+      links:
+        rocket-chat/mongo: mongo
+      metadata: &id036
+        io.rancher.service.hash: e7379577e1059c3c7ef84ae610d5ad26da9fe25b
+      name: rocketchat
+      ports: &id037
+      - 3000:3000/tcp
+      scale: 1
+      sidekicks: &id038 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - containers:
+      - rocket-chat_hubot_1
+      expose: &id039 []
+      external_ips: &id040 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id041
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: &id042
+        io.rancher.service.hash: b1ef36ea20e8dbdefb29b5f0a5a27cc1628fb433
+      name: hubot
+      ports: &id043
+      - 3001:8080/tcp
+      scale: 1
+      sidekicks: &id044 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - *id002
+    - containers:
+      - wordpress_db_1
+      expose: &id045 []
+      external_ips: &id046 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id047
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+      links: {}
+      metadata: &id048
+        io.rancher.service.hash: 98d0039e2af5f4d47e0c2eef103b27e8f2717cd3
+      name: db
+      ports: &id049 []
+      scale: 1
+      sidekicks: &id050 []
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - containers:
+      - wordpress_wordpress_1
+      expose: &id051 []
+      external_ips: &id052 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id053
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+      links:
+        wordpress/db: mysql
+      metadata: &id054
+        io.rancher.service.hash: ed9d26dd9fce0e66bedfe5bc5e1dd0b92a856bf3
+      name: wordpress
+      ports: &id055
+      - 8484:80/tcp
+      scale: 1
+      sidekicks: &id056 []
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - &id006
+      containers:
+      - triple_alpha_1
+      expose: &id057 []
+      external_ips: &id058 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id059
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+      links: {}
+      metadata: &id060
+        io.rancher.service.hash: 8a10554df3bc6a092dd0099d9780457380526030
+      name: alpha
+      ports: &id061
+      - 40001:80/tcp
+      scale: 1
+      sidekicks: &id062 []
+      stack_name: triple
+      token: null
+      uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+      vip: null
+    - containers:
+      - triple_charlie_1
+      expose: &id063 []
+      external_ips: &id064 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id065
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+      links: {}
+      metadata: &id066
+        io.rancher.service.hash: b062d386eafe5066caa89eae642a7ed77f09bdde
+      name: charlie
+      ports: &id067
+      - 40003:80/tcp
+      scale: 1
+      sidekicks: &id068 []
+      stack_name: triple
+      token: null
+      uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+      vip: null
+    - containers:
+      - triple_bravo_1
+      expose: &id069 []
+      external_ips: &id070 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id071
+        io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+      links: {}
+      metadata: &id072
+        io.rancher.service.hash: 614c40a8effc3bd450e5ebe2345e4611acf9665c
+      name: bravo
+      ports: &id073
+      - 40002:80/tcp
+      scale: 1
+      sidekicks: &id074 []
+      stack_name: triple
+      token: null
+      uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+      vip: null
+    stacks:
+    - &id007
+      environment_name: Default
+      environment_uuid: adminProject
+      name: triple
+      services:
+      - alpha
+      - charlie
+      - bravo
+      uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+    - &id010
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - mongo
+      - rocketchat
+      - hubot
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - *id003
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - db
+      - wordpress
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 22-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.228.29:
+    self:
+      container: *id004
+      host: *id005
+      service: *id006
+      stack: *id007
+  10.42.128.187:
+    self:
+      container: *id008
+      host: *id005
+      service: *id009
+      stack: *id010
+latest: &id086
+  10.42.207.141:
+    self:
+      container: *id001
+      host: *id005
+      service: &id017
+        containers:
+        - *id001
+        create_index: 1
+        expose: *id011
+        external_ips: *id012
+        fqdn: null
+        hostname: null
+        kind: service
+        labels: *id013
+        links: {}
+        metadata: *id014
+        name: ghost
+        ports: *id015
+        scale: 1
+        sidekicks: *id016
+        stack_name: ghost
+        token: null
+        uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+        vip: null
+      stack: &id081
+        environment_name: Default
+        environment_uuid: adminProject
+        name: ghost
+        services:
+        - *id017
+        uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+  default:
+    containers:
+    - *id008
+    - *id018
+    - *id001
+    - *id004
+    - *id019
+    - *id020
+    - *id021
+    - *id022
+    - *id023
+    - *id024
+    - *id025
+    - *id026
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 130.211.160.79
+        hostId: 1
+        hostname: aa-leo-tmp-10acre-2
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-2
+        uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    services:
+    - &id078
+      containers:
+      - *id008
+      create_index: 1
+      expose: *id027
+      external_ips: *id028
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id029
+      links: {}
+      metadata: *id030
+      name: mongo
+      ports: *id031
+      scale: 1
+      sidekicks: *id032
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - &id079
+      containers:
+      - *id019
+      create_index: 1
+      expose: *id033
+      external_ips: *id034
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id035
+      links:
+        rocket-chat/mongo: mongo
+      metadata: *id036
+      name: rocketchat
+      ports: *id037
+      scale: 1
+      sidekicks: *id038
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - &id080
+      containers:
+      - *id023
+      create_index: 1
+      expose: *id039
+      external_ips: *id040
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id041
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: *id042
+      name: hubot
+      ports: *id043
+      scale: 1
+      sidekicks: *id044
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - *id017
+    - &id082
+      containers:
+      - *id021
+      create_index: 1
+      expose: *id045
+      external_ips: *id046
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id047
+      links: {}
+      metadata: *id048
+      name: db
+      ports: *id049
+      scale: 1
+      sidekicks: *id050
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - &id083
+      containers:
+      - *id025
+      create_index: 1
+      expose: *id051
+      external_ips: *id052
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id053
+      links:
+        wordpress/db: mysql
+      metadata: *id054
+      name: wordpress
+      ports: *id055
+      scale: 1
+      sidekicks: *id056
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - &id075
+      containers:
+      - *id004
+      create_index: 1
+      expose: *id057
+      external_ips: *id058
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id059
+      links: {}
+      metadata: *id060
+      name: alpha
+      ports: *id061
+      scale: 1
+      sidekicks: *id062
+      stack_name: triple
+      token: null
+      uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+      vip: null
+    - &id076
+      containers:
+      - *id022
+      create_index: 1
+      expose: *id063
+      external_ips: *id064
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id065
+      links: {}
+      metadata: *id066
+      name: charlie
+      ports: *id067
+      scale: 1
+      sidekicks: *id068
+      stack_name: triple
+      token: null
+      uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+      vip: null
+    - &id077
+      containers:
+      - *id026
+      create_index: 1
+      expose: *id069
+      external_ips: *id070
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id071
+      links: {}
+      metadata: *id072
+      name: bravo
+      ports: *id073
+      scale: 1
+      sidekicks: *id074
+      stack_name: triple
+      token: null
+      uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+      vip: null
+    stacks:
+    - &id084
+      environment_name: Default
+      environment_uuid: adminProject
+      name: triple
+      services:
+      - *id075
+      - *id076
+      - *id077
+      uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+    - &id085
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - *id078
+      - *id079
+      - *id080
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - *id081
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - *id082
+      - *id083
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 22-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.228.29:
+    self:
+      container: *id004
+      host: *id005
+      service: *id075
+      stack: *id084
+  10.42.128.187:
+    self:
+      container: *id008
+      host: *id005
+      service: *id078
+      stack: *id085
+'2015-12-19': *id086
+

--- a/tests/answers.host3.yml
+++ b/tests/answers.host3.yml
@@ -1,0 +1,908 @@
+'2015-07-25':
+  10.42.68.158:
+    self:
+      container: &id001
+        create_index: 1
+        external_id: 2c50f56e006ea76c8c8966b270ae417c29c67532ea82b07ee0fd966cb52f1f4f
+        health_state: null
+        host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+        hostname: null
+        ips:
+        - 10.42.68.158
+        labels:
+          io.rancher.project.name: triple
+          io.rancher.service.deployment.unit: 6e902556-c228-4ec7-8724-99ecfe7c6bbb
+          io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+          io.rancher.project_service.name: triple/bravo
+          io.rancher.stack.name: triple
+          io.rancher.stack_service.name: triple/bravo
+          io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+          io.rancher.container.uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+          io.rancher.container.name: triple_bravo_1
+          io.rancher.container.ip: 10.42.68.158/16
+        name: triple_bravo_1
+        ports:
+        - 104.155.146.133:40002:80/tcp
+        primary_ip: 10.42.68.158
+        service_index: '1'
+        service_name: bravo
+        stack_name: triple
+        start_count: 1
+        state: running
+        uuid: ed795a0b-9cf0-4691-91f5-126c540aa661
+      host: &id005
+        agent_ip: 104.155.146.133
+        hostId: 3
+        hostname: aa-leo-tmp-10acre-3
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-3
+        uuid: a8567665-9735-4111-9b42-20c8836564d6
+      service: &id002
+        containers:
+        - triple_bravo_1
+        expose: &id011 []
+        external_ips: &id012 []
+        fqdn: null
+        hostname: null
+        kind: service
+        labels: &id013
+          io.rancher.service.hash: 89ab683562baa6b5fe369aff692afffad9c9a327
+        links: {}
+        metadata: &id014
+          io.rancher.service.hash: 614c40a8effc3bd450e5ebe2345e4611acf9665c
+        name: bravo
+        ports: &id015
+        - 40002:80/tcp
+        scale: 1
+        sidekicks: &id016 []
+        stack_name: triple
+        token: null
+        uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+        vip: null
+      stack: &id003
+        environment_name: Default
+        environment_uuid: adminProject
+        name: triple
+        services:
+        - alpha
+        - charlie
+        - bravo
+        uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+  default:
+    containers:
+    - &id032
+      create_index: 1
+      external_id: 779f71ede6f82f3adce7efa0b3ba6c6dc44c103e14e3065425b67cc8bbe96432
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.128.187
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 20e2f2b1-f6fd-4d06-b387-3c1e3a702d5a
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/mongo
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/mongo
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+        io.rancher.container.uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+        io.rancher.container.name: rocket-chat_mongo_1
+        io.rancher.container.ip: 10.42.128.187/16
+      name: rocket-chat_mongo_1
+      ports: []
+      primary_ip: 10.42.128.187
+      service_index: '1'
+      service_name: mongo
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 7113cb84-d968-4ad4-8648-8441095106a6
+    - &id033
+      create_index: null
+      external_id: f5ad0d2bb345471c5ae6dd14995d791b82246889e63b516fa0b5e0084353f331
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.221.125
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '4'
+        io.rancher.container.ip: 10.42.221.125/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.221.125
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: e70da6ca-e6ee-4dd1-a837-89e96fa42938
+    - &id034
+      create_index: 1
+      external_id: d75ca8b68526de0bab930bf50e1ec1366b91a8805cb11f3bd33760f90f23a361
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.207.141
+      labels:
+        io.rancher.project.name: ghost
+        io.rancher.service.deployment.unit: 734ab88d-a730-444a-8e84-be3fd5dfd123
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: ghost/ghost
+        io.rancher.stack.name: ghost
+        io.rancher.stack_service.name: ghost/ghost
+        io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+        io.rancher.container.uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+        io.rancher.container.name: ghost_ghost_1
+        io.rancher.container.ip: 10.42.207.141/16
+      name: ghost_ghost_1
+      ports:
+      - 130.211.160.79:8987:2368/tcp
+      primary_ip: 10.42.207.141
+      service_index: '1'
+      service_name: ghost
+      stack_name: ghost
+      start_count: 1
+      state: running
+      uuid: c736b294-d9b9-47fe-9faa-c2d9a7efc4cc
+    - &id017
+      create_index: 1
+      external_id: 648aa7d8a6c4eb32c9617186a37c7278b71c5e4c4af9523eb7fd38387608fb6c
+      health_state: null
+      host_uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+      hostname: null
+      ips:
+      - 10.42.228.29
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: 31f6b033-f70f-4b05-9023-48c455b21443
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/alpha
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/alpha
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+        io.rancher.container.uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+        io.rancher.container.name: triple_alpha_1
+        io.rancher.container.ip: 10.42.228.29/16
+      name: triple_alpha_1
+      ports:
+      - 130.211.160.79:40001:80/tcp
+      primary_ip: 10.42.228.29
+      service_index: '1'
+      service_name: alpha
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: ae60eae3-1f4d-491e-aafb-0ff1969438d9
+    - &id035
+      create_index: 1
+      external_id: 5573e7627fe7c85defc6a20d07d3da2c9da65f3b29611e0d1cf3d9ceb57d6747
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.73.81
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 62c74524-7e7f-4509-8c23-922fbedc8d59
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/rocketchat
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/rocketchat
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+        io.rancher.container.uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+        io.rancher.container.name: rocket-chat_rocketchat_1
+        io.rancher.container.ip: 10.42.73.81/16
+      name: rocket-chat_rocketchat_1
+      ports:
+      - 104.155.135.97:3000:3000/tcp
+      primary_ip: 10.42.73.81
+      service_index: '1'
+      service_name: rocketchat
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 0b1f0629-862e-468a-a97c-4e6dfff37daf
+    - &id036
+      create_index: null
+      external_id: 46ba9baec31c016ffaaff659da8f296bcf3854fa580da87f6d564c4994dffa1c
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.53.162
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '5'
+        io.rancher.container.ip: 10.42.53.162/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.53.162
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: 7807e9b3-b25e-4569-8b15-69bd3c339573
+    - &id037
+      create_index: 1
+      external_id: 1e7de486fd7a1213edd377218de6fc62010e4f733356d879521983ce90a6f127
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.114.70
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 39dc601a-1a03-46bb-b925-643ffcc2dc71
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/db
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/db
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+        io.rancher.container.uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+        io.rancher.container.name: wordpress_db_1
+        io.rancher.container.ip: 10.42.114.70/16
+      name: wordpress_db_1
+      ports: []
+      primary_ip: 10.42.114.70
+      service_index: '1'
+      service_name: db
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 71fdf56e-574e-4b10-b142-995ac5783f59
+    - &id024
+      create_index: 1
+      external_id: f987f4dd7004d95e4647f9f2f4c65732cfd817b9179b3b74676e6a4f0a55d060
+      health_state: null
+      host_uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+      hostname: null
+      ips:
+      - 10.42.248.225
+      labels:
+        io.rancher.project.name: triple
+        io.rancher.service.deployment.unit: b5192eb8-4345-466f-b486-60154aef9115
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: triple/charlie
+        io.rancher.stack.name: triple
+        io.rancher.stack_service.name: triple/charlie
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+        io.rancher.container.uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+        io.rancher.container.name: triple_charlie_1
+        io.rancher.container.ip: 10.42.248.225/16
+      name: triple_charlie_1
+      ports:
+      - 104.155.135.97:40003:80/tcp
+      primary_ip: 10.42.248.225
+      service_index: '1'
+      service_name: charlie
+      stack_name: triple
+      start_count: 1
+      state: running
+      uuid: 90c62a80-208c-4b06-9662-b1b0f10ec6d7
+    - &id004
+      create_index: 1
+      external_id: 172e18f098643c47de02f8b050790f797bac66413184d4359cb2b02618f0530e
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.223.250
+      labels:
+        io.rancher.project.name: rocket-chat
+        io.rancher.service.deployment.unit: 319aaf3d-33b7-4cd6-b177-4169e8f3a5fb
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: rocket-chat/hubot
+        io.rancher.stack.name: rocket-chat
+        io.rancher.stack_service.name: rocket-chat/hubot
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+        io.rancher.container.uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+        io.rancher.container.name: rocket-chat_hubot_1
+        io.rancher.container.ip: 10.42.223.250/16
+      name: rocket-chat_hubot_1
+      ports:
+      - 104.155.146.133:3001:8080/tcp
+      primary_ip: 10.42.223.250
+      service_index: '1'
+      service_name: hubot
+      stack_name: rocket-chat
+      start_count: 1
+      state: running
+      uuid: 8f9029f2-a53d-4649-93a9-5451694101e9
+    - &id038
+      create_index: null
+      external_id: 1664a225ff2f47294234285f13786a359c2379698f586f67f4554ff79e2b6c24
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.105.87
+      labels:
+        io.rancher.container.system: NetworkAgent
+        io.rancher.container.uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+        io.rancher.container.name: Network Agent
+        io.rancher.container.agent_id: '6'
+        io.rancher.container.ip: 10.42.105.87/16
+      name: Network Agent
+      ports: []
+      primary_ip: 10.42.105.87
+      service_index: null
+      service_name: null
+      stack_name: null
+      start_count: 1
+      state: running
+      uuid: ef76c4ca-beb8-4940-9913-daf40e290f0e
+    - &id008
+      create_index: 1
+      external_id: 9a28718f55a59e398a95935ec1ec567b86ddeef207835a682662583b0c4c3b36
+      health_state: null
+      host_uuid: a8567665-9735-4111-9b42-20c8836564d6
+      hostname: null
+      ips:
+      - 10.42.187.22
+      labels:
+        io.rancher.project.name: wordpress
+        io.rancher.service.deployment.unit: 8e6c4f99-77a1-410d-aa48-cd9c14f0474e
+        io.rancher.service.launch.config: io.rancher.service.primary.launch.config
+        io.rancher.project_service.name: wordpress/wordpress
+        io.rancher.stack.name: wordpress
+        io.rancher.stack_service.name: wordpress/wordpress
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+        io.rancher.container.uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+        io.rancher.container.name: wordpress_wordpress_1
+        io.rancher.container.ip: 10.42.187.22/16
+      name: wordpress_wordpress_1
+      ports:
+      - 104.155.146.133:8484:80/tcp
+      primary_ip: 10.42.187.22
+      service_index: '1'
+      service_name: wordpress
+      stack_name: wordpress
+      start_count: 1
+      state: running
+      uuid: 9bca3f2b-c22a-462c-a9b6-eaa47b4aad79
+    - *id001
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 104.155.146.133
+        hostId: 3
+        hostname: aa-leo-tmp-10acre-3
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-3
+        uuid: a8567665-9735-4111-9b42-20c8836564d6
+    services:
+    - containers:
+      - rocket-chat_mongo_1
+      expose: &id039 []
+      external_ips: &id040 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id041
+        io.rancher.service.hash: e793dc53c75b19b1d39a4249679518e5bb056b4f
+      links: {}
+      metadata: &id042
+        io.rancher.service.hash: 16294d680b8d3cbf5967a29a833bdec0730e25d5
+      name: mongo
+      ports: &id043 []
+      scale: 1
+      sidekicks: &id044 []
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - containers:
+      - rocket-chat_rocketchat_1
+      expose: &id045 []
+      external_ips: &id046 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id047
+        io.rancher.service.hash: 8977397abec00b351475ed4482806bcd88169263
+      links:
+        rocket-chat/mongo: mongo
+      metadata: &id048
+        io.rancher.service.hash: e7379577e1059c3c7ef84ae610d5ad26da9fe25b
+      name: rocketchat
+      ports: &id049
+      - 3000:3000/tcp
+      scale: 1
+      sidekicks: &id050 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - &id006
+      containers:
+      - rocket-chat_hubot_1
+      expose: &id051 []
+      external_ips: &id052 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id053
+        io.rancher.service.hash: fe5ef314de2393325e1a124feac9bfd443c64f97
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: &id054
+        io.rancher.service.hash: b1ef36ea20e8dbdefb29b5f0a5a27cc1628fb433
+      name: hubot
+      ports: &id055
+      - 3001:8080/tcp
+      scale: 1
+      sidekicks: &id056 []
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - containers:
+      - ghost_ghost_1
+      expose: &id057 []
+      external_ips: &id058 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id059
+        io.rancher.service.hash: 61b2a20ec578100a2d3c75875f0870096338ece5
+      links: {}
+      metadata: &id060
+        io.rancher.service.hash: f49280e1f709117b76693b638834791e4f4ef0fd
+      name: ghost
+      ports: &id061
+      - 8987:2368/tcp
+      scale: 1
+      sidekicks: &id062 []
+      stack_name: ghost
+      token: null
+      uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+      vip: null
+    - containers:
+      - wordpress_db_1
+      expose: &id063 []
+      external_ips: &id064 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id065
+        io.rancher.service.hash: 9eb241eb1f5b721fa11358879eb20c00c66aae11
+      links: {}
+      metadata: &id066
+        io.rancher.service.hash: 98d0039e2af5f4d47e0c2eef103b27e8f2717cd3
+      name: db
+      ports: &id067 []
+      scale: 1
+      sidekicks: &id068 []
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - &id009
+      containers:
+      - wordpress_wordpress_1
+      expose: &id069 []
+      external_ips: &id070 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id071
+        io.rancher.service.hash: 92589bfe33e5e4168725c67628b58e5e72d011fa
+      links:
+        wordpress/db: mysql
+      metadata: &id072
+        io.rancher.service.hash: ed9d26dd9fce0e66bedfe5bc5e1dd0b92a856bf3
+      name: wordpress
+      ports: &id073
+      - 8484:80/tcp
+      scale: 1
+      sidekicks: &id074 []
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - containers:
+      - triple_alpha_1
+      expose: &id018 []
+      external_ips: &id019 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id020
+        io.rancher.service.hash: 9ae263a03d69737acd36a49d07f9288050cc1141
+      links: {}
+      metadata: &id021
+        io.rancher.service.hash: 8a10554df3bc6a092dd0099d9780457380526030
+      name: alpha
+      ports: &id022
+      - 40001:80/tcp
+      scale: 1
+      sidekicks: &id023 []
+      stack_name: triple
+      token: null
+      uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+      vip: null
+    - containers:
+      - triple_charlie_1
+      expose: &id025 []
+      external_ips: &id026 []
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: &id027
+        io.rancher.service.hash: f36ff6db027f9c86f7360df47a4fbe5b50220062
+      links: {}
+      metadata: &id028
+        io.rancher.service.hash: b062d386eafe5066caa89eae642a7ed77f09bdde
+      name: charlie
+      ports: &id029
+      - 40003:80/tcp
+      scale: 1
+      sidekicks: &id030 []
+      stack_name: triple
+      token: null
+      uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+      vip: null
+    - *id002
+    stacks:
+    - *id003
+    - &id007
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - mongo
+      - rocketchat
+      - hubot
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: ghost
+      services:
+      - ghost
+      uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+    - &id010
+      environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - db
+      - wordpress
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 16-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.223.250:
+    self:
+      container: *id004
+      host: *id005
+      service: *id006
+      stack: *id007
+  10.42.187.22:
+    self:
+      container: *id008
+      host: *id005
+      service: *id009
+      stack: *id010
+latest: &id086
+  10.42.68.158:
+    self:
+      container: *id001
+      host: *id005
+      service: &id031
+        containers:
+        - *id001
+        create_index: 1
+        expose: *id011
+        external_ips: *id012
+        fqdn: null
+        hostname: null
+        kind: service
+        labels: *id013
+        links: {}
+        metadata: *id014
+        name: bravo
+        ports: *id015
+        scale: 1
+        sidekicks: *id016
+        stack_name: triple
+        token: null
+        uuid: efbfd8e3-58cf-45d9-b802-5c38cf900273
+        vip: null
+      stack: &id077
+        environment_name: Default
+        environment_uuid: adminProject
+        name: triple
+        services:
+        - &id075
+          containers:
+          - *id017
+          create_index: 1
+          expose: *id018
+          external_ips: *id019
+          fqdn: null
+          hostname: null
+          kind: service
+          labels: *id020
+          links: {}
+          metadata: *id021
+          name: alpha
+          ports: *id022
+          scale: 1
+          sidekicks: *id023
+          stack_name: triple
+          token: null
+          uuid: abb9dd2d-78f2-4544-99e3-6a61c2a52f6d
+          vip: null
+        - &id076
+          containers:
+          - *id024
+          create_index: 1
+          expose: *id025
+          external_ips: *id026
+          fqdn: null
+          hostname: null
+          kind: service
+          labels: *id027
+          links: {}
+          metadata: *id028
+          name: charlie
+          ports: *id029
+          scale: 1
+          sidekicks: *id030
+          stack_name: triple
+          token: null
+          uuid: 9e8a5e40-2d54-4c2d-a65e-7b1da85cdcc9
+          vip: null
+        - *id031
+        uuid: 32c79860-15c7-4ebb-8692-2b5ab1dbbc58
+  default:
+    containers:
+    - *id032
+    - *id033
+    - *id034
+    - *id017
+    - *id035
+    - *id036
+    - *id037
+    - *id024
+    - *id004
+    - *id038
+    - *id008
+    - *id001
+    hosts:
+    - agent_ip: 130.211.160.79
+      hostId: 1
+      hostname: aa-leo-tmp-10acre-2
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-2
+      uuid: ce5d0147-8f2d-4e87-86ea-977dd61f83df
+    - agent_ip: 104.155.135.97
+      hostId: 2
+      hostname: aa-leo-tmp-10acre-1
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-1
+      uuid: 5d67de07-c644-4001-a219-11d2c7662c82
+    - agent_ip: 104.155.146.133
+      hostId: 3
+      hostname: aa-leo-tmp-10acre-3
+      labels:
+        io.rancher.host.linux_kernel_version: '3.19'
+        io.rancher.host.docker_version: '1.10'
+      name: aa-leo-tmp-10acre-3
+      uuid: a8567665-9735-4111-9b42-20c8836564d6
+    self:
+      host:
+        agent_ip: 104.155.146.133
+        hostId: 3
+        hostname: aa-leo-tmp-10acre-3
+        labels:
+          io.rancher.host.linux_kernel_version: '3.19'
+          io.rancher.host.docker_version: '1.10'
+        name: aa-leo-tmp-10acre-3
+        uuid: a8567665-9735-4111-9b42-20c8836564d6
+    services:
+    - &id078
+      containers:
+      - *id032
+      create_index: 1
+      expose: *id039
+      external_ips: *id040
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id041
+      links: {}
+      metadata: *id042
+      name: mongo
+      ports: *id043
+      scale: 1
+      sidekicks: *id044
+      stack_name: rocket-chat
+      token: null
+      uuid: ed007641-3a25-4a32-bca9-fdcea240cdec
+      vip: null
+    - &id079
+      containers:
+      - *id035
+      create_index: 1
+      expose: *id045
+      external_ips: *id046
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id047
+      links:
+        rocket-chat/mongo: mongo
+      metadata: *id048
+      name: rocketchat
+      ports: *id049
+      scale: 1
+      sidekicks: *id050
+      stack_name: rocket-chat
+      token: null
+      uuid: 1bf95584-b081-4ee7-8aa8-bb42c2f4c4e7
+      vip: null
+    - &id080
+      containers:
+      - *id004
+      create_index: 1
+      expose: *id051
+      external_ips: *id052
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id053
+      links:
+        rocket-chat/rocketchat: rocketchat
+      metadata: *id054
+      name: hubot
+      ports: *id055
+      scale: 1
+      sidekicks: *id056
+      stack_name: rocket-chat
+      token: null
+      uuid: 483e97df-5429-4979-bbb7-e5741b43dfa0
+      vip: null
+    - &id081
+      containers:
+      - *id034
+      create_index: 1
+      expose: *id057
+      external_ips: *id058
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id059
+      links: {}
+      metadata: *id060
+      name: ghost
+      ports: *id061
+      scale: 1
+      sidekicks: *id062
+      stack_name: ghost
+      token: null
+      uuid: c2916a99-1f55-45d9-a8f8-8c025a6b332d
+      vip: null
+    - &id082
+      containers:
+      - *id037
+      create_index: 1
+      expose: *id063
+      external_ips: *id064
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id065
+      links: {}
+      metadata: *id066
+      name: db
+      ports: *id067
+      scale: 1
+      sidekicks: *id068
+      stack_name: wordpress
+      token: null
+      uuid: de3afe4b-85d9-49f6-8e56-e83bd9bd4519
+      vip: null
+    - &id083
+      containers:
+      - *id008
+      create_index: 1
+      expose: *id069
+      external_ips: *id070
+      fqdn: null
+      hostname: null
+      kind: service
+      labels: *id071
+      links:
+        wordpress/db: mysql
+      metadata: *id072
+      name: wordpress
+      ports: *id073
+      scale: 1
+      sidekicks: *id074
+      stack_name: wordpress
+      token: null
+      uuid: 2ec5913d-b1e6-4efd-bfd7-b74fa18ac315
+      vip: null
+    - *id075
+    - *id076
+    - *id031
+    stacks:
+    - *id077
+    - &id084
+      environment_name: Default
+      environment_uuid: adminProject
+      name: rocket-chat
+      services:
+      - *id078
+      - *id079
+      - *id080
+      uuid: 78d48e0c-0b36-44a8-9faf-f985903862f3
+    - environment_name: Default
+      environment_uuid: adminProject
+      name: ghost
+      services:
+      - *id081
+      uuid: 7f1754d6-836d-4b54-80d2-6ffe748321cd
+    - &id085
+      environment_name: Default
+      environment_uuid: adminProject
+      name: wordpress
+      services:
+      - *id082
+      - *id083
+      uuid: 55e44a6c-730e-425f-a98c-2447429e193e
+    version: 16-257aff5cc23042701e4b6e49146ac4f33de95ee93d14f3484f87f4e23b378943
+  10.42.223.250:
+    self:
+      container: *id004
+      host: *id005
+      service: *id080
+      stack: *id084
+  10.42.187.22:
+    self:
+      container: *id008
+      host: *id005
+      service: *id083
+      stack: *id085
+'2015-12-19': *id086
+

--- a/tests/metadata_test.go
+++ b/tests/metadata_test.go
@@ -1,0 +1,195 @@
+package metadata_test
+
+import (
+	"github.com/Sirupsen/logrus"
+	"github.com/rancher/go-rancher-metadata/metadata"
+	rmd "github.com/rancher/rancher-metadata"
+	//"reflect"
+	"testing"
+)
+
+const (
+	mdVersion = "2015-12-19"
+
+	listenPort1       = ":33001"
+	listenReloadPort1 = ":33011"
+	metadataURL1      = "http://localhost" + listenPort1 + "/" + mdVersion
+	answers1          = "./answers.host1.yml"
+
+	listenPort2       = ":33002"
+	listenReloadPort2 = ":33012"
+	metadataURL2      = "http://localhost" + listenPort2 + "/" + mdVersion
+	answers2          = "./answers.host2.yml"
+
+	listenPort3       = ":33003"
+	listenReloadPort3 = ":33013"
+	metadataURL3      = "http://localhost" + listenPort3 + "/" + mdVersion
+	answers3          = "./answers.host3.yml"
+)
+
+func init() {
+
+	logrus.SetLevel(logrus.DebugLevel)
+	runAllTestMetadataServers()
+}
+
+func runAllTestMetadataServers() {
+	runTestMetadataServer1()
+	runTestMetadataServer2()
+	runTestMetadataServer3()
+}
+
+func runTestMetadataServer1() {
+	runTestMetadataServer(answers1, metadataURL1, listenPort1, listenReloadPort1)
+}
+
+func runTestMetadataServer2() {
+	runTestMetadataServer(answers2, metadataURL2, listenPort2, listenReloadPort2)
+}
+
+func runTestMetadataServer3() {
+	runTestMetadataServer(answers3, metadataURL3, listenPort3, listenReloadPort3)
+}
+
+func runTestMetadataServer(answers, url, listenPort, listenReloadPort string) {
+
+	logrus.Debugf("Starting Test Metadata Server")
+
+	sc := rmd.NewServerConfig(
+		answers,
+		listenPort,
+		listenReloadPort,
+		true,
+	)
+
+	go func() { sc.Start() }()
+}
+
+func TestGetContainers(t *testing.T) {
+
+	clientIP1 := "10.42.73.81"
+
+	mc1, err := metadata.NewClientWithIPAndWait(metadataURL1, clientIP1)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+
+	containers, err := mc1.GetContainers()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	expectedContainersLength := 12
+	actualContainersLength := len(containers)
+	if actualContainersLength != expectedContainersLength {
+		t.Error("expectedContainersLength: %v actualContainersLength: %v", expectedContainersLength, actualContainersLength)
+	}
+
+}
+
+func TestGetSelfHost(t *testing.T) {
+
+	clientIP1 := "10.42.73.81"
+	mc1, err := metadata.NewClientWithIPAndWait(metadataURL1, clientIP1)
+	logrus.Debugf("mc1: %v", mc1)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+	selfHost1, err := mc1.GetSelfHost()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	expectedSelfHost1Name := "aa-leo-tmp-10acre-1"
+	if selfHost1.Name != expectedSelfHost1Name {
+		t.Error("expected: %s, actual: %s", expectedSelfHost1Name, selfHost1.Name)
+	}
+
+	logrus.Debugf("selfHost1: %v", selfHost1)
+
+	clientIP2 := "10.42.128.187"
+	mc2, err := metadata.NewClientWithIPAndWait(metadataURL2, clientIP2)
+	logrus.Debugf("mc2: %v", mc2)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+	selfHost2, err := mc2.GetSelfHost()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	expectedSelfHost2Name := "aa-leo-tmp-10acre-2"
+	if selfHost2.Name != expectedSelfHost2Name {
+		t.Error("expected: %s, actual: %s", expectedSelfHost2Name, selfHost2.Name)
+	}
+}
+
+func TestGetSelfContainer(t *testing.T) {
+
+	clientIP1 := "10.42.73.81"
+	mc1, err := metadata.NewClientWithIPAndWait(metadataURL1, clientIP1)
+	logrus.Debugf("mc1: %v", mc1)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+	c1, err := mc1.GetSelfContainer()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	logrus.Debugf("c1: %v", c1)
+
+	clientIP2 := "10.42.128.187"
+	mc2, err := metadata.NewClientWithIPAndWait(metadataURL2, clientIP2)
+	logrus.Debugf("mc2: %v", mc2)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+	c2, err := mc2.GetSelfContainer()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	if c2.PrimaryIp != clientIP2 {
+		t.Error("expected: %s, actual: %c", clientIP2, c2.PrimaryIp)
+	}
+	logrus.Debugf("c2: %+v", c2)
+}
+
+func TestGetServices(t *testing.T) {
+
+	clientIP1 := "10.42.73.81"
+	mc1, err := metadata.NewClientWithIPAndWait(metadataURL1, clientIP1)
+	logrus.Debugf("mc1: %v", mc1)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+
+	services, err := mc1.GetServices()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+
+	expectedServicesLength := 9
+	actualServicesLength := len(services)
+	if actualServicesLength != expectedServicesLength {
+		t.Error("expectedServicesLength: %v actualServicesLength: %v", expectedServicesLength, actualServicesLength)
+	}
+}
+
+func TestGetSelfService(t *testing.T) {
+
+	clientIP1 := "10.42.73.81"
+	mc1, err := metadata.NewClientWithIPAndWait(metadataURL1, clientIP1)
+	logrus.Debugf("mc1: %v", mc1)
+	if err != nil {
+		logrus.Errorf("couldn't create metadata client")
+	}
+
+	selfService, err := mc1.GetSelfService()
+	if err != nil {
+		t.Error("not expecting error, got: %v", err)
+	}
+	logrus.Debugf("selfService: %+v", selfService)
+
+	actualNumOfServiceContainers := len(selfService.Containers)
+	expectedNumOfServiceContainers := 1
+	if actualNumOfServiceContainers != expectedNumOfServiceContainers {
+		t.Error("expected %v got %v", expectedNumOfServiceContainers, actualNumOfServiceContainers)
+	}
+}


### PR DESCRIPTION
@ibuildthecloud @alena1108 @cloudnautique @cjellick 

Overview of the changes:
- Adding an option to specify the IP address to use for the client when talking to rancher metadata URL. This is useful to run different instances of rancher-metadata, connect as different clients and run different tests.
