### PR TITLE
Reuse http.Client instance, properly close resp.Body

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"time"
 )
 
 type Client interface {
@@ -27,17 +28,22 @@ type Client interface {
 }
 
 type client struct {
-	url string
-	ip  string
+	url    string
+	ip     string
+	client *http.Client
+}
+
+func newClient(url, ip string) *client {
+	return &client{url, ip, &http.Client{Timeout: 10 * time.Second}}
 }
 
 func NewClient(url string) Client {
 	ip := ""
-	return &client{url, ip}
+	return newClient(url, ip)
 }
 
 func NewClientWithIPAndWait(url, ip string) (Client, error) {
-	client := &client{url, ip}
+	client := newClient(url, ip)
 
 	if err := testConnection(client); err != nil {
 		return nil, err
@@ -48,7 +54,7 @@ func NewClientWithIPAndWait(url, ip string) (Client, error) {
 
 func NewClientAndWait(url string) (Client, error) {
 	ip := ""
-	client := &client{url, ip}
+	client := newClient(url, ip)
 
 	if err := testConnection(client); err != nil {
 		return nil, err
@@ -58,22 +64,21 @@ func NewClientAndWait(url string) (Client, error) {
 }
 
 func (m *client) SendRequest(path string) ([]byte, error) {
-	client := &http.Client{}
 	req, err := http.NewRequest("GET", m.url+path, nil)
 	req.Header.Add("Accept", "application/json")
 	if m.ip != "" {
 		req.Header.Add("X-Forwarded-For", m.ip)
 	}
-	resp, err := client.Do(req)
+	resp, err := m.client.Do(req)
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		return nil, fmt.Errorf("Error %v accessing %v path", resp.StatusCode, path)
 	}
 
-	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Reuse http.Client instance, properly close resp.Body

This should fix an issue with lingering TCP keep-alive connections to rancher-metadata which severely affects rancher hosts with beancounter agent running