### PR TITLE
Fix OnChange

### DIFF
--- a/metadata/change.go
+++ b/metadata/change.go
@@ -9,8 +9,10 @@ import (
 )
 
 func (m *client) OnChangeWithError(intervalSeconds int, do func(string)) error {
-	version := "init"
+	return m.onChangeFromVersionWithError("init", intervalSeconds, do)
+}
 
+func (m *client) onChangeFromVersionWithError(version string, intervalSeconds int, do func(string)) error {
 	for {
 		newVersion, err := m.waitVersion(intervalSeconds, version)
 		if err != nil {
@@ -28,9 +30,14 @@ func (m *client) OnChangeWithError(intervalSeconds int, do func(string)) error {
 }
 
 func (m *client) OnChange(intervalSeconds int, do func(string)) {
+	version := "init"
+	updateVersionAndDo := func(v string) {
+		version = v
+		do(version)
+	}
 	interval := time.Duration(intervalSeconds)
 	for {
-		if err := m.OnChangeWithError(intervalSeconds, do); err != nil {
+		if err := m.onChangeFromVersionWithError(version, intervalSeconds, updateVersionAndDo); err != nil {
 			logrus.Errorf("Error reading metadata version: %v", err)
 		}
 		time.Sleep(interval * time.Second)


### PR DESCRIPTION
Fix OnChange

It was calling OnChangeWithError in a loop, which would reset the initial version to "init" on every invocation.