### PR TITLE
github.com/Sirupsen/logrus has been renamed to github.com/sirupsen/lo…

### DIFF
--- a/metadata/change.go
+++ b/metadata/change.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func (m *client) OnChangeWithError(intervalSeconds int, do func(string)) error {


### PR DESCRIPTION
…grus

This match is needed because otherwise you'll run into this problem when using go mod on other project that uses this one.

```
make run-dev
go generate
autogen/genstatic/gen.go
go build ./cmd/traefik
../../../../pkg/mod/github.com/rancher/go-rancher-metadata@v0.0.0-20170929155856-d2103caca587/metadata/change.go:8:2: case-insensitive import collision: "github.com/Sirupsen/logrus" and "github.com/sirupsen/logrus"
make: *** [run-dev] Error 1
```